### PR TITLE
1 allow to add custom parameters to every request

### DIFF
--- a/src/main/java/de/olech2412/adapter/dbadapter/APIConfiguration.java
+++ b/src/main/java/de/olech2412/adapter/dbadapter/APIConfiguration.java
@@ -1,8 +1,5 @@
 package de.olech2412.adapter.dbadapter;
 
-import de.olech2412.adapter.dbadapter.model.station.Station;
-import de.olech2412.adapter.dbadapter.model.stop.Stop;
-import de.olech2412.adapter.dbadapter.model.trip.Trip;
 import de.olech2412.adapter.dbadapter.request.Request;
 import de.olech2412.adapter.dbadapter.request.RequestPath;
 import lombok.Getter;
@@ -18,16 +15,14 @@ import java.util.List;
  * @see DB_Adapter_v6
  * @since 0.0.1
  */
+@Getter
 public class APIConfiguration {
 
-    @Getter
     @Setter
     private String baseUrl = "https://v6.db.transport.rest";
 
-    @Getter
     private List<Request> requests;
 
-    @Getter
     @Setter
     private Proxy proxy;
     
@@ -42,23 +37,18 @@ public class APIConfiguration {
         requests = List.of(
                 new Request.RequestBuilder()
                         .setApiEndpoint(RequestPath.STOPS_BY_ID)
-                        .setResponseClass(Stop.class)
                         .build(),
                 new Request.RequestBuilder()
                         .setApiEndpoint(RequestPath.STOPS_BY_ID_DEPARTURES)
-                        .setResponseClass(Trip.class)
                         .build(),
                 new Request.RequestBuilder()
                         .setApiEndpoint(RequestPath.STOPS_BY_ID_ARRIVALS)
-                        .setResponseClass(Trip.class)
                         .build(),
                 new Request.RequestBuilder()
                         .setApiEndpoint(RequestPath.STATIONS_BY_ID)
-                        .setResponseClass(Station.class)
                         .build(),
                 new Request.RequestBuilder()
                         .setApiEndpoint(RequestPath.STATIONS)
-                        .setResponseClass(Station.class)
                         .build()
         );
     }

--- a/src/main/java/de/olech2412/adapter/dbadapter/DB_Adapter_v6.java
+++ b/src/main/java/de/olech2412/adapter/dbadapter/DB_Adapter_v6.java
@@ -134,7 +134,8 @@ public class DB_Adapter_v6 {
     private Request getRequest(RequestPath requestPath) {
         for (Request request : apiConfiguration.getRequests()) {
             if (request.getApiEndpoint().equals(requestPath.getPath())) {
-                return request;
+                // important! otherwise it would change the ApiEndpoint permanent
+                return new Request.RequestBuilder().setApiEndpoint(requestPath).build(); // Create a new request with the same api endpoint
             }
         }
 

--- a/src/main/java/de/olech2412/adapter/dbadapter/DB_Adapter_v6.java
+++ b/src/main/java/de/olech2412/adapter/dbadapter/DB_Adapter_v6.java
@@ -10,6 +10,8 @@ import de.olech2412.adapter.dbadapter.model.stop.Stop;
 import de.olech2412.adapter.dbadapter.model.trip.Trip;
 import de.olech2412.adapter.dbadapter.request.Request;
 import de.olech2412.adapter.dbadapter.request.RequestPath;
+import de.olech2412.adapter.dbadapter.request.parameters.Parameter;
+import de.olech2412.adapter.dbadapter.request.parameters.ParameterEvaluator;
 import org.apache.commons.io.IOUtils;
 
 import javax.net.ssl.HttpsURLConnection;
@@ -18,6 +20,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * This class is responsible for making requests to the API and returning the response
@@ -41,101 +44,16 @@ public class DB_Adapter_v6 {
     }
 
     /**
-     * Get all departures of a stop by id with a duration and a number of results
-     *
-     * @param id       the id of the stop
-     * @param duration the duration in minutes
-     * @param results  the number of results
-     * @return the departures as an array of trips
-     * @throws IOException if the request fails
-     */
-    public Trip[] getDeparturesByStopIdWithDurationAndResults(Integer id, Integer duration, Integer results) throws IOException {
-        Request request = getRequest(RequestPath.STOPS_BY_ID_DEPARTURES);
-        request.setApiEndpoint(String.format(request.getApiEndpoint(), id) + "?duration=" + duration + "&" + "results=" + results);
-        Result<JsonObject, Error> result = performRequest(request);
-
-        if (!result.isSuccess()) {
-            throw new IOException(result.getError().getError());
-        } else {
-            JsonArray jsonArray = result.getData().getAsJsonArray("departures");
-            return gson.fromJson(jsonArray, Trip[].class);
-        }
-    }
-
-    /**
-     * Get all arrivals of a stop by id with a duration and a number of results
-     *
-     * @param id       the id of the stop
-     * @param duration the duration in minutes
-     * @param results  the number of results
-     * @return the arrivals as an array of trips
-     * @throws IOException if the request fails
-     */
-    public Trip[] getArrivalsByStopIdWithDurationAndResults(Integer id, Integer duration, Integer results) throws IOException {
-        Request request = getRequest(RequestPath.STOPS_BY_ID_ARRIVALS);
-        request.setApiEndpoint(String.format(request.getApiEndpoint(), id) + "?duration=" + duration + "&" + "results=" + results);
-        Result<JsonObject, Error> result = performRequest(request);
-
-        if (!result.isSuccess()) {
-            throw new IOException(result.getError().getError());
-        } else {
-            JsonArray jsonArray = result.getData().getAsJsonArray("arrivals");
-            return gson.fromJson(jsonArray, Trip[].class);
-        }
-    }
-
-    /**
-     * Get all departures of a stop by id with a duration
-     *
-     * @param id       the id of the stop
-     * @param duration the duration in minutes
-     * @return the departures as an array of trips
-     * @throws IOException if the request fails
-     */
-    public Trip[] getDeparturesByStopIdWithDuration(Integer id, Integer duration) throws IOException {
-        Request request = getRequest(RequestPath.STOPS_BY_ID_DEPARTURES);
-        request.setApiEndpoint(String.format(request.getApiEndpoint(), id) + "?duration=" + duration);
-        Result<JsonObject, Error> result = performRequest(request);
-
-        if (!result.isSuccess()) {
-            throw new IOException(result.getError().getError());
-        } else {
-            JsonArray jsonArray = result.getData().getAsJsonArray("departures");
-            return gson.fromJson(jsonArray, Trip[].class);
-        }
-    }
-
-    /**
-     * Get all arrivals of a stop by id with a duration
-     *
-     * @param id       the id of the stop
-     * @param duration the duration in minutes
-     * @return the arrivals as an array of trips
-     * @throws IOException if the request fails
-     */
-    public Trip[] getArrivalsByStopIdWithDuration(Integer id, Integer duration) throws IOException {
-        Request request = getRequest(RequestPath.STOPS_BY_ID_ARRIVALS);
-        request.setApiEndpoint(String.format(request.getApiEndpoint(), id) + "?duration=" + duration);
-        Result<JsonObject, Error> result = performRequest(request);
-
-        if (!result.isSuccess()) {
-            throw new IOException(result.getError().getError());
-        } else {
-            JsonArray jsonArray = result.getData().getAsJsonArray("arrivals");
-            return gson.fromJson(jsonArray, Trip[].class);
-        }
-    }
-
-    /**
      * Get all departures of a stop by id
      *
      * @param id the id of the stop
      * @return the departures as an array of trips
      * @throws IOException if the request fails
      */
-    public Trip[] getDeparturesByStopId(Integer id) throws IOException {
+    public Trip[] getDeparturesByStopId(Integer id, List<Parameter<?>> parameters) throws IOException {
+        String parameter = ParameterEvaluator.convertToString(parameters);
         Request request = getRequest(RequestPath.STOPS_BY_ID_DEPARTURES);
-        request.setApiEndpoint(String.format(request.getApiEndpoint(), id));
+        request.setApiEndpoint(String.format(request.getApiEndpoint(), id) + parameter);
         Result<JsonObject, Error> result = performRequest(request);
 
         if (!result.isSuccess()) {
@@ -153,9 +71,10 @@ public class DB_Adapter_v6 {
      * @return the arrivals as an array of trips
      * @throws IOException if the request fails
      */
-    public Trip[] getArrivalsByStopId(Integer id) throws IOException {
+    public Trip[] getArrivalsByStopId(Integer id, List<Parameter<?>> parameters) throws IOException {
+        String parameter = ParameterEvaluator.convertToString(parameters);
         Request request = getRequest(RequestPath.STOPS_BY_ID_ARRIVALS);
-        request.setApiEndpoint(String.format(request.getApiEndpoint(), id));
+        request.setApiEndpoint(String.format(request.getApiEndpoint(), id) + parameter);
         Result<JsonObject, Error> result = performRequest(request);
 
         if (!result.isSuccess()) {
@@ -173,9 +92,10 @@ public class DB_Adapter_v6 {
      * @return the stop
      * @throws IOException if the request fails
      */
-    public Stop getStopById(Integer id) throws IOException {
+    public Stop getStopById(Integer id, List<Parameter<?>> parameters) throws IOException {
+        String parameter = ParameterEvaluator.convertToString(parameters);
         Request request = getRequest(RequestPath.STOPS_BY_ID);
-        request.setApiEndpoint(String.format(request.getApiEndpoint(), id));
+        request.setApiEndpoint(String.format(request.getApiEndpoint(), id) + parameter);
         Result<JsonObject, Error> result = performRequest(request);
 
         if (!result.isSuccess()) {
@@ -192,9 +112,10 @@ public class DB_Adapter_v6 {
      * @return the station
      * @throws IOException if the request fails
      */
-    public Station getStationById(Integer id) throws IOException {
+    public Station getStationById(Integer id, List<Parameter<?>> parameters) throws IOException {
+        String parameter = ParameterEvaluator.convertToString(parameters);
         Request request = getRequest(RequestPath.STATIONS_BY_ID);
-        request.setApiEndpoint(String.format(request.getApiEndpoint(), id));
+        request.setApiEndpoint(String.format(request.getApiEndpoint(), id) + parameter);
         Result<JsonObject, Error> result = performRequest(request);
 
         if (!result.isSuccess()) {

--- a/src/main/java/de/olech2412/adapter/dbadapter/request/Request.java
+++ b/src/main/java/de/olech2412/adapter/dbadapter/request/Request.java
@@ -7,11 +7,11 @@ import lombok.Setter;
  * This class stores information about all possible requests
  * It stores the base url and the class that represents the response
  */
+@Setter
+@Getter
 public class Request {
 
     // The endpoint of the api
-    @Getter
-    @Setter
     private String apiEndpoint;
 
     // get the endpoint of the api

--- a/src/main/java/de/olech2412/adapter/dbadapter/request/Request.java
+++ b/src/main/java/de/olech2412/adapter/dbadapter/request/Request.java
@@ -14,10 +14,6 @@ public class Request {
     @Setter
     private String apiEndpoint;
 
-    // The class that represents the response
-    @Getter
-    private Class<?> responseClass;
-
     // get the endpoint of the api
     private Request() {
     }
@@ -28,9 +24,6 @@ public class Request {
         // The endpoint of the api
         private RequestPath apiEndpoint;
 
-        // The class that represents the response
-        private Class<?> responseClass;
-
         public RequestBuilder() {
         }
 
@@ -40,17 +33,10 @@ public class Request {
             return this;
         }
 
-        // set the class that represents the response
-        public RequestBuilder setResponseClass(Class<?> responseClass) {
-            this.responseClass = responseClass;
-            return this;
-        }
-
         // build the request
         public Request build() {
             Request request = new Request();
             request.apiEndpoint = this.apiEndpoint.getPath();
-            request.responseClass = this.responseClass;
             return request;
         }
     }

--- a/src/main/java/de/olech2412/adapter/dbadapter/request/parameters/Parameter.java
+++ b/src/main/java/de/olech2412/adapter/dbadapter/request/parameters/Parameter.java
@@ -34,6 +34,9 @@ public class Parameter<T> {
     public static class ParameterBuilder {
         private final List<Parameter<?>> parameters = new ArrayList<>();
 
+        public ParameterBuilder() {
+        }
+
         /**
          * Adds a new Parameter to the list.
          *

--- a/src/main/java/de/olech2412/adapter/dbadapter/request/parameters/Parameter.java
+++ b/src/main/java/de/olech2412/adapter/dbadapter/request/parameters/Parameter.java
@@ -18,12 +18,12 @@ public class Parameter<T> {
     private final T value;
 
     /**
-     * Private constructor for creating a new Parameter.
+     * Constructor for creating a new Parameter.
      *
      * @param requestParametersNames the name of the parameter
      * @param value                  the value of the parameter
      */
-    private Parameter(RequestParametersNames requestParametersNames, T value) {
+    public Parameter(RequestParametersNames requestParametersNames, T value) {
         this.requestParametersNames = requestParametersNames;
         this.value = value;
     }

--- a/src/main/java/de/olech2412/adapter/dbadapter/request/parameters/Parameter.java
+++ b/src/main/java/de/olech2412/adapter/dbadapter/request/parameters/Parameter.java
@@ -1,0 +1,59 @@
+package de.olech2412.adapter.dbadapter.request.parameters;
+
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class represents a parameter that can be used in a request.
+ * It contains a name and a value of generic type T.
+ *
+ * @param <T> the type of the value of the parameter
+ */
+@Getter
+public class Parameter<T> {
+
+    private final RequestParametersNames requestParametersNames;
+    private final T value;
+
+    /**
+     * Private constructor for creating a new Parameter.
+     *
+     * @param requestParametersNames the name of the parameter
+     * @param value                  the value of the parameter
+     */
+    private Parameter(RequestParametersNames requestParametersNames, T value) {
+        this.requestParametersNames = requestParametersNames;
+        this.value = value;
+    }
+
+    /**
+     * This class is used to build a list of Parameters.
+     */
+    public static class ParameterBuilder {
+        private final List<Parameter<?>> parameters = new ArrayList<>();
+
+        /**
+         * Adds a new Parameter to the list.
+         *
+         * @param requestParameter the name of the parameter
+         * @param value            the value of the parameter
+         * @return the ParameterBuilder instance
+         */
+        public <T> ParameterBuilder add(RequestParametersNames requestParameter, T value) {
+            parameters.add(new Parameter<>(requestParameter, value));
+            return this;
+        }
+
+        /**
+         * Returns a new list of Parameters.
+         *
+         * @return a new list of Parameters
+         */
+        public List<Parameter<?>> build() {
+            return new ArrayList<>(parameters);
+        }
+    }
+
+}

--- a/src/main/java/de/olech2412/adapter/dbadapter/request/parameters/ParameterEvaluator.java
+++ b/src/main/java/de/olech2412/adapter/dbadapter/request/parameters/ParameterEvaluator.java
@@ -1,0 +1,23 @@
+package de.olech2412.adapter.dbadapter.request.parameters;
+
+import java.util.List;
+
+public class ParameterEvaluator {
+
+    public static String convertToString(List<Parameter<?>> parameters) {
+        StringBuilder stringBuilder = new StringBuilder();
+        for (Parameter<?> parameter : parameters) {
+            if (stringBuilder.isEmpty()) {
+                stringBuilder.append("?");
+            }
+            stringBuilder.append(parameter.getRequestParametersNames().toString());
+            stringBuilder.append("=");
+            stringBuilder.append(parameter.getValue().toString());
+            if (parameters.indexOf(parameter) != parameters.size() - 1) {
+                stringBuilder.append("&");
+            }
+        }
+        return stringBuilder.toString();
+    }
+
+}

--- a/src/main/java/de/olech2412/adapter/dbadapter/request/parameters/ParameterEvaluator.java
+++ b/src/main/java/de/olech2412/adapter/dbadapter/request/parameters/ParameterEvaluator.java
@@ -2,18 +2,30 @@ package de.olech2412.adapter.dbadapter.request.parameters;
 
 import java.util.List;
 
+/**
+ * This class is responsible for evaluating a list of Parameters.
+ * It provides a method to convert a list of Parameters to a String.
+ */
 public class ParameterEvaluator {
 
+    /**
+     * Converts a list of Parameters to a String.
+     * The resulting String is a concatenation of the parameter names and their values,
+     * separated by an equals sign. Each parameter is separated by an ampersand.
+     *
+     * @param parameters the list of Parameters to convert
+     * @return a String representation of the list of Parameters
+     */
     public static String convertToString(List<Parameter<?>> parameters) {
         StringBuilder stringBuilder = new StringBuilder();
         for (Parameter<?> parameter : parameters) {
-            if (stringBuilder.isEmpty()) {
+            if (stringBuilder.isEmpty()) { // if its the first parameter, add a question mark
                 stringBuilder.append("?");
             }
             stringBuilder.append(parameter.getRequestParametersNames().toString());
             stringBuilder.append("=");
             stringBuilder.append(parameter.getValue().toString());
-            if (parameters.indexOf(parameter) != parameters.size() - 1) {
+            if (parameters.indexOf(parameter) != parameters.size() - 1) { // if its not the last parameter, add an ampersand
                 stringBuilder.append("&");
             }
         }

--- a/src/main/java/de/olech2412/adapter/dbadapter/request/parameters/ParameterEvaluator.java
+++ b/src/main/java/de/olech2412/adapter/dbadapter/request/parameters/ParameterEvaluator.java
@@ -17,6 +17,8 @@ public class ParameterEvaluator {
      * @return a String representation of the list of Parameters
      */
     public static String convertToString(List<Parameter<?>> parameters) {
+        if (parameters.isEmpty())
+            return ""; // if the list is empty, return an empty string (otherwise the url would be invalid
         StringBuilder stringBuilder = new StringBuilder();
         for (Parameter<?> parameter : parameters) {
             if (stringBuilder.isEmpty()) { // if its the first parameter, add a question mark

--- a/src/main/java/de/olech2412/adapter/dbadapter/request/parameters/RequestParameters.java
+++ b/src/main/java/de/olech2412/adapter/dbadapter/request/parameters/RequestParameters.java
@@ -1,0 +1,34 @@
+package de.olech2412.adapter.dbadapter.request.parameters;
+
+import lombok.Getter;
+
+@Getter
+public enum RequestParameters {
+
+    PRETTY("pretty"), // pretty print
+
+    LINES_OF_STOPS("linesOfStops"), // parse & print lines for each stop?
+
+    LANGUAGE("language"), // language
+
+    WHEN("when"), // date and time
+
+    DIRECTION("direction"), // direction
+
+    DURATION("duration"), // duration
+
+    RESULTS("results"), // number of results
+
+    REMARKS("remarks"); // parse & print remarks? like hints and warnings
+
+    private final String parameter;
+
+    RequestParameters(String parameter) {
+        this.parameter = parameter;
+    }
+
+    @Override
+    public String toString() {
+        return parameter;
+    }
+}

--- a/src/main/java/de/olech2412/adapter/dbadapter/request/parameters/RequestParametersNames.java
+++ b/src/main/java/de/olech2412/adapter/dbadapter/request/parameters/RequestParametersNames.java
@@ -3,7 +3,7 @@ package de.olech2412.adapter.dbadapter.request.parameters;
 import lombok.Getter;
 
 @Getter
-public enum RequestParameters {
+public enum RequestParametersNames {
 
     PRETTY("pretty"), // pretty print
 
@@ -23,7 +23,7 @@ public enum RequestParameters {
 
     private final String parameter;
 
-    RequestParameters(String parameter) {
+    RequestParametersNames(String parameter) {
         this.parameter = parameter;
     }
 

--- a/src/main/java/de/olech2412/adapter/dbadapter/request/parameters/RequestParametersNames.java
+++ b/src/main/java/de/olech2412/adapter/dbadapter/request/parameters/RequestParametersNames.java
@@ -15,7 +15,7 @@ public enum RequestParametersNames {
 
     DIRECTION("direction"), // direction
 
-    DURATION("duration"), // duration
+    DURATION("duration"), // duration (fetch data for the next n minutes)
 
     RESULTS("results"), // number of results
 

--- a/src/test/java/de/olech2412/adapter/dbadapter/APIConfigurationTest.java
+++ b/src/test/java/de/olech2412/adapter/dbadapter/APIConfigurationTest.java
@@ -29,6 +29,7 @@ public class APIConfigurationTest {
         Assert.assertEquals(apiConfiguration.getRequests().size(), expectedRequests.size());
         for (int i = 0; i < apiConfiguration.getRequests().size(); i++) {
             Assert.assertEquals(apiConfiguration.getRequests().get(i).getApiEndpoint(), expectedRequests.get(i).getApiEndpoint());
+            Assert.assertEquals(apiConfiguration.getRequests().get(i), expectedRequests.get(i));
         }
     }
 

--- a/src/test/java/de/olech2412/adapter/dbadapter/APIConfigurationTest.java
+++ b/src/test/java/de/olech2412/adapter/dbadapter/APIConfigurationTest.java
@@ -29,7 +29,6 @@ public class APIConfigurationTest {
         Assert.assertEquals(apiConfiguration.getRequests().size(), expectedRequests.size());
         for (int i = 0; i < apiConfiguration.getRequests().size(); i++) {
             Assert.assertEquals(apiConfiguration.getRequests().get(i).getApiEndpoint(), expectedRequests.get(i).getApiEndpoint());
-            Assert.assertEquals(apiConfiguration.getRequests().get(i), expectedRequests.get(i));
         }
     }
 

--- a/src/test/java/de/olech2412/adapter/dbadapter/APIConfigurationTest.java
+++ b/src/test/java/de/olech2412/adapter/dbadapter/APIConfigurationTest.java
@@ -1,8 +1,5 @@
 package de.olech2412.adapter.dbadapter;
 
-import de.olech2412.adapter.dbadapter.model.station.Station;
-import de.olech2412.adapter.dbadapter.model.stop.Stop;
-import de.olech2412.adapter.dbadapter.model.trip.Trip;
 import de.olech2412.adapter.dbadapter.request.Request;
 import de.olech2412.adapter.dbadapter.request.RequestPath;
 import org.junit.Assert;
@@ -22,17 +19,17 @@ public class APIConfigurationTest {
     @Test
     public void test_getRequests() {
         List<Request> expectedRequests = List.of(
-                new Request.RequestBuilder().setApiEndpoint(RequestPath.STOPS_BY_ID).setResponseClass(Stop.class).build(),
-                new Request.RequestBuilder().setApiEndpoint(RequestPath.STOPS_BY_ID_DEPARTURES).setResponseClass(Trip.class).build(),
-                new Request.RequestBuilder().setApiEndpoint(RequestPath.STOPS_BY_ID_ARRIVALS).setResponseClass(Trip.class).build(),
-                new Request.RequestBuilder().setApiEndpoint(RequestPath.STATIONS_BY_ID).setResponseClass(Station.class).build(),
-                new Request.RequestBuilder().setApiEndpoint(RequestPath.STATIONS).setResponseClass(Station.class).build()
+                new Request.RequestBuilder().setApiEndpoint(RequestPath.STOPS_BY_ID).build(),
+                new Request.RequestBuilder().setApiEndpoint(RequestPath.STOPS_BY_ID_DEPARTURES).build(),
+                new Request.RequestBuilder().setApiEndpoint(RequestPath.STOPS_BY_ID_ARRIVALS).build(),
+                new Request.RequestBuilder().setApiEndpoint(RequestPath.STATIONS_BY_ID).build(),
+                new Request.RequestBuilder().setApiEndpoint(RequestPath.STATIONS).build()
         );
         APIConfiguration apiConfiguration = new APIConfiguration();
         Assert.assertEquals(apiConfiguration.getRequests().size(), expectedRequests.size());
         for (int i = 0; i < apiConfiguration.getRequests().size(); i++) {
             Assert.assertEquals(apiConfiguration.getRequests().get(i).getApiEndpoint(), expectedRequests.get(i).getApiEndpoint());
-            Assert.assertEquals(apiConfiguration.getRequests().get(i).getResponseClass(), expectedRequests.get(i).getResponseClass());
+            Assert.assertEquals(apiConfiguration.getRequests().get(i), expectedRequests.get(i));
         }
     }
 

--- a/src/test/java/de/olech2412/adapter/dbadapter/DB_Adapter_v6Test.java
+++ b/src/test/java/de/olech2412/adapter/dbadapter/DB_Adapter_v6Test.java
@@ -3,6 +3,8 @@ package de.olech2412.adapter.dbadapter;
 import de.olech2412.adapter.dbadapter.model.station.Station;
 import de.olech2412.adapter.dbadapter.model.stop.Stop;
 import de.olech2412.adapter.dbadapter.model.trip.Trip;
+import de.olech2412.adapter.dbadapter.request.parameters.Parameter;
+import de.olech2412.adapter.dbadapter.request.parameters.RequestParametersNames;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 
@@ -82,6 +84,19 @@ public class DB_Adapter_v6Test {
         Assertions.assertThrows(IOException.class, () -> {
             db_adapter_v6.getArrivalsByStopId(new Random().nextInt(), Collections.EMPTY_LIST);
         });
+    }
+
+    @Test
+    public void testParameter() throws IOException {
+        Trip[] arrivals = db_adapter_v6.getArrivalsByStopId(stopId, Collections.EMPTY_LIST);
+        Trip[] arrivalsWithParameter = db_adapter_v6.getArrivalsByStopId(stopId, new Parameter.ParameterBuilder().add(RequestParametersNames.RESULTS, 1).build());
+
+        Assertions.assertNotNull(arrivals);
+        Assertions.assertNotNull(arrivalsWithParameter);
+        Assertions.assertNotEquals(0, arrivals.length);
+        Assertions.assertNotEquals(0, arrivalsWithParameter.length);
+        Assertions.assertNotEquals(arrivals.length, arrivalsWithParameter.length);
+        Assertions.assertEquals(1, arrivalsWithParameter.length);
     }
 
 }

--- a/src/test/java/de/olech2412/adapter/dbadapter/DB_Adapter_v6Test.java
+++ b/src/test/java/de/olech2412/adapter/dbadapter/DB_Adapter_v6Test.java
@@ -87,7 +87,7 @@ public class DB_Adapter_v6Test {
     }
 
     @Test
-    public void testParameter() throws IOException {
+    public void testParameterResults() throws IOException {
         Trip[] arrivals = db_adapter_v6.getArrivalsByStopId(stopId, Collections.EMPTY_LIST);
         Trip[] arrivalsWithParameter = db_adapter_v6.getArrivalsByStopId(stopId, new Parameter.ParameterBuilder().add(RequestParametersNames.RESULTS, 1).build());
 

--- a/src/test/java/de/olech2412/adapter/dbadapter/DB_Adapter_v6Test.java
+++ b/src/test/java/de/olech2412/adapter/dbadapter/DB_Adapter_v6Test.java
@@ -18,81 +18,9 @@ public class DB_Adapter_v6Test {
     int stopId = 8503000;
 
     @Test
-    public void testGetArrivalsWithValidStopIdAndDurationAndResults() throws IOException {
-        int duration = 30;
-        int results = 10;
-
-        Trip[] arrivals = db_adapter_v6.getArrivalsByStopIdWithDurationAndResults(stopId, duration, results);
-
-        Assertions.assertNotNull(arrivals);
-        Assertions.assertTrue(arrivals.length <= results);
-        Assertions.assertNotEquals(0, arrivals.length);
-
-        Trip arrival = arrivals[0];
-        Assertions.assertNotNull(arrival);
-        Assertions.assertNotNull(arrival.getStop());
-        Assertions.assertNotNull(arrival.getCreatedAt());
-        Assertions.assertNotNull(arrival.getLine());
-        Assertions.assertNotNull(arrival.getTripId());
-    }
-
-    @Test
-    public void testGetDeparturesByStopIdWithDurationAndResults() throws IOException {
-        int duration = 30;
-        int results = 10;
-
-        Trip[] departures = db_adapter_v6.getDeparturesByStopIdWithDurationAndResults(stopId, duration, results);
-
-        Assertions.assertNotNull(departures);
-        Assertions.assertTrue(departures.length <= results);
-        Assertions.assertNotEquals(0, departures.length);
-
-        Trip departure = departures[0];
-        Assertions.assertNotNull(departure);
-        Assertions.assertNotNull(departure.getStop());
-        Assertions.assertNotNull(departure.getCreatedAt());
-        Assertions.assertNotNull(departure.getLine());
-        Assertions.assertNotNull(departure.getTripId());
-    }
-
-    @Test
-    public void testGetDeparturesByStopIdWithDuration() throws IOException {
-        int duration = 30;
-
-        Trip[] departures = db_adapter_v6.getDeparturesByStopIdWithDuration(stopId, duration);
-
-        Assertions.assertNotNull(departures);
-        Assertions.assertNotEquals(0, departures.length);
-
-        Trip departure = departures[0];
-        Assertions.assertNotNull(departure);
-        Assertions.assertNotNull(departure.getStop());
-        Assertions.assertNotNull(departure.getCreatedAt());
-        Assertions.assertNotNull(departure.getLine());
-        Assertions.assertNotNull(departure.getTripId());
-    }
-
-    @Test
-    public void testGetArrivalsByStopIdWithDuration() throws IOException {
-        int duration = 30;
-
-        Trip[] arrivals = db_adapter_v6.getArrivalsByStopIdWithDuration(stopId, duration);
-
-        Assertions.assertNotNull(arrivals);
-        Assertions.assertNotEquals(0, arrivals.length);
-
-        Trip arrival = arrivals[0];
-        Assertions.assertNotNull(arrival);
-        Assertions.assertNotNull(arrival.getStop());
-        Assertions.assertNotNull(arrival.getCreatedAt());
-        Assertions.assertNotNull(arrival.getLine());
-        Assertions.assertNotNull(arrival.getTripId());
-    }
-
-    @Test
     public void testGetArrivalsByStopId() throws IOException {
 
-        Trip[] arrivals = db_adapter_v6.getArrivalsByStopId(stopId);
+        Trip[] arrivals = db_adapter_v6.getArrivalsByStopId(stopId, Collections.EMPTY_LIST);
 
         Assertions.assertNotNull(arrivals);
         Assertions.assertNotEquals(0, arrivals.length);
@@ -108,7 +36,7 @@ public class DB_Adapter_v6Test {
     @Test
     public void testGetDeparturesByStopId() throws IOException {
 
-        Trip[] departures = db_adapter_v6.getDeparturesByStopId(stopId);
+        Trip[] departures = db_adapter_v6.getDeparturesByStopId(stopId, Collections.EMPTY_LIST);
 
         Assertions.assertNotNull(departures);
         Assertions.assertNotEquals(0, departures.length);
@@ -124,7 +52,7 @@ public class DB_Adapter_v6Test {
     @Test
     public void testGetStopById() throws IOException {
 
-        Stop stop = db_adapter_v6.getStopById(stopId);
+        Stop stop = db_adapter_v6.getStopById(stopId, Collections.EMPTY_LIST);
 
         Assertions.assertNotNull(stop);
         Assertions.assertNotNull(stop.getCreatedAt());
@@ -152,7 +80,7 @@ public class DB_Adapter_v6Test {
         });
 
         Assertions.assertThrows(IOException.class, () -> {
-            db_adapter_v6.getArrivalsByStopId(new Random().nextInt());
+            db_adapter_v6.getArrivalsByStopId(new Random().nextInt(), Collections.EMPTY_LIST);
         });
     }
 

--- a/src/test/java/de/olech2412/adapter/dbadapter/DB_Adapter_v6Test.java
+++ b/src/test/java/de/olech2412/adapter/dbadapter/DB_Adapter_v6Test.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Random;
 
 public class DB_Adapter_v6Test {
@@ -135,7 +136,7 @@ public class DB_Adapter_v6Test {
     @Test
     public void testGetStationById() throws IOException {
 
-        Station station = db_adapter_v6.getStationById(8010159);
+        Station station = db_adapter_v6.getStationById(8010159, Collections.EMPTY_LIST);
 
         Assertions.assertNotNull(station);
         Assertions.assertNotNull(station.getCreatedAt());
@@ -147,7 +148,7 @@ public class DB_Adapter_v6Test {
     @Test
     public void testWrongInput() throws IOException {
         Assertions.assertThrows(IOException.class, () -> {
-            db_adapter_v6.getStationById(-1);
+            db_adapter_v6.getStationById(-1, Collections.EMPTY_LIST);
         });
 
         Assertions.assertThrows(IOException.class, () -> {

--- a/src/test/java/de/olech2412/adapter/dbadapter/request/parameters/ParameterEvaluatorTest.java
+++ b/src/test/java/de/olech2412/adapter/dbadapter/request/parameters/ParameterEvaluatorTest.java
@@ -1,0 +1,34 @@
+package de.olech2412.adapter.dbadapter.request.parameters;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class ParameterEvaluatorTest {
+
+    @Test
+    public void convertToStringReturnsEmptyStringWhenNoParameters() {
+        List<Parameter<?>> parameters = Arrays.asList();
+        String result = ParameterEvaluator.convertToString(parameters);
+        Assert.assertEquals("", result);
+    }
+
+    @Test
+    public void convertToStringReturnsCorrectStringForSingleParameter() {
+        Parameter<?> parameter = new Parameter<>(RequestParametersNames.RESULTS, 1);
+        List<Parameter<?>> parameters = Arrays.asList(parameter);
+        String result = ParameterEvaluator.convertToString(parameters);
+        Assert.assertEquals("?results=1", result);
+    }
+
+    @Test
+    public void convertToStringReturnsCorrectStringForMultipleParameters() {
+        Parameter<?> parameter1 = new Parameter<>(RequestParametersNames.DIRECTION, "München");
+        Parameter<?> parameter2 = new Parameter<>(RequestParametersNames.RESULTS, 2);
+        List<Parameter<?>> parameters = Arrays.asList(parameter1, parameter2);
+        String result = ParameterEvaluator.convertToString(parameters);
+        Assert.assertEquals("?direction=München&results=2", result);
+    }
+}

--- a/src/test/java/de/olech2412/adapter/dbadapter/request/parameters/ParameterTest.java
+++ b/src/test/java/de/olech2412/adapter/dbadapter/request/parameters/ParameterTest.java
@@ -1,0 +1,39 @@
+package de.olech2412.adapter.dbadapter.request.parameters;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class ParameterTest {
+
+    @Test
+    public void parameterBuilderAddsParameterToList() {
+        Parameter.ParameterBuilder parameterBuilder = new Parameter.ParameterBuilder();
+        parameterBuilder.add(RequestParametersNames.RESULTS, 1);
+        List<Parameter<?>> parameters = parameterBuilder.build();
+
+        Assert.assertEquals(1, parameters.size());
+        Assert.assertEquals(RequestParametersNames.RESULTS, parameters.get(0).getRequestParametersNames());
+        Assert.assertEquals(1, parameters.get(0).getValue());
+    }
+
+    @Test
+    public void parameterBuilderCreatesEmptyListWhenNoParametersAdded() {
+        Parameter.ParameterBuilder parameterBuilder = new Parameter.ParameterBuilder();
+        List<Parameter<?>> parameters = parameterBuilder.build();
+
+        Assert.assertTrue(parameters.isEmpty());
+    }
+
+    @Test
+    public void parameterBuilderCreatesNewListOnEachBuild() {
+        Parameter.ParameterBuilder parameterBuilder = new Parameter.ParameterBuilder();
+        parameterBuilder.add(RequestParametersNames.RESULTS, 1);
+
+        List<Parameter<?>> parameters1 = parameterBuilder.build();
+        List<Parameter<?>> parameters2 = parameterBuilder.build();
+
+        Assert.assertNotSame(parameters1, parameters2);
+    }
+}

--- a/src/test/java/de/olech2412/adapter/dbadapter/request/parameters/RequestParametersNamesTest.java
+++ b/src/test/java/de/olech2412/adapter/dbadapter/request/parameters/RequestParametersNamesTest.java
@@ -1,0 +1,19 @@
+package de.olech2412.adapter.dbadapter.request.parameters;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RequestParametersNamesTest {
+
+    @Test
+    public void toStringReturnsCorrectParameterName() {
+        Assert.assertEquals("pretty", RequestParametersNames.PRETTY.toString());
+        Assert.assertEquals("linesOfStops", RequestParametersNames.LINES_OF_STOPS.toString());
+        Assert.assertEquals("language", RequestParametersNames.LANGUAGE.toString());
+        Assert.assertEquals("when", RequestParametersNames.WHEN.toString());
+        Assert.assertEquals("direction", RequestParametersNames.DIRECTION.toString());
+        Assert.assertEquals("duration", RequestParametersNames.DURATION.toString());
+        Assert.assertEquals("results", RequestParametersNames.RESULTS.toString());
+        Assert.assertEquals("remarks", RequestParametersNames.REMARKS.toString());
+    }
+}


### PR DESCRIPTION
Allow users to add custom parameters to their requests. Makes the code more comfortable and easier to maintain.
The user can add a parameter that is not supported in the used request -> thats a task for the api to ignore. Would be useless to implement rules for that because a new release is needed if the api changes something.